### PR TITLE
Add helper file for mac os installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Build PyInstaller application
       run: |
-        pyinstaller --name RstEyeApp --windowed --onefile --add-data "med.gif:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py
+        pyinstaller --name RstEyeApp --windowed --onefile --add-data "med.gif:." --add-data "rsteye.png:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py
 
     - name: Zip the application
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY . /app
 WORKDIR /app
 
 # Build the binary
-RUN pyinstaller --name RstEyeApp --onefile --add-data "med.gif:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py
+RUN pyinstaller --name RstEyeApp --onefile --add-data "med.gif:." --add-data "rsteye.png:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
       - python3 -m pip install pillow pyinstaller python-dotenv
 
     - run below command to create a binary file to package it as deb package 
-      `pyinstaller --name RstEyeApp --onefile --add-data "med.gif:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py`    
+      `pyinstaller --name RstEyeApp --windowed --onefile --add-data "med.gif:." --add-data "rsteye.png:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py`    
     
     - create a deb package(`dpkg-deb --build rsteye`) after copying the binary to deb_package(rsteye) usr/bin and creating DEBIAN files  
 
@@ -74,9 +74,32 @@
        - python3 -m pip install pillow pyinstaller python-dotenv
   
      - run
-       `pyinstaller --name RstEyeApp --windowed --onefile --add-data "med.gif:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py` 
+       `pyinstaller --name RstEyeApp --windowed --onefile --add-data "med.gif:." --add-data "rsteye.png:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks app.py`
      
-     - create a zip file using `zip -r RstEyeApp.zip dist/RstEyeApp.app`
+     - create installer fater following below instructions 
+        
+        - # Create the directory structure
+        mkdir -p distroot/Applications
+
+        # Copy the .app file
+        cp -R dist/RstEyeApp.app distroot/Applications/
+
+        # Create the postinstall script inside mac_os_files
+        cat <<EOF > mac_os_files/postinstall
+        #!/bin/bash
+        cp /Library/LaunchDaemons/com.rsteye.rsteye.plist
+        launchctl load /Library/LaunchDaemons/com.rsteye.rsteye.plist
+        EOF
+
+        # Make the postinstall script executable
+        chmod +x mac_os_files/postinstall
+
+        # Ensure the plist file is ready and accessible in mac_os_files
+        # Example: cp ./com.rsteye.rsteye.plist mac_os_files/
+
+        # Build the installer package
+        pkgbuild --root distroot --scripts mac_os_files --identifier com.rsteye.rsteye --version 1.0 RstEyeApp.pkg
+
 
 
   - Windows
@@ -89,7 +112,7 @@
     - Build PyInstaller Application
 
       - Run the following command to create a binary file:
-        `pyinstaller --name RstEyeApp --onefile --add-data "med.gif;." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks --icon=rsteye.ico app.py`
+        `pyinstaller --name RstEyeApp --onefile --add-data "med.gif;." --add-data "rsteye.png:." --hidden-import=PIL.ImageTk --additional-hooks-dir=hooks --icon=rsteye.ico app.py`
 
     - Install Inno setup(https://jrsoftware.org/isdl.php#stable) for windows and run below command to generate an installer 
       - "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" setup.iss

--- a/README.md
+++ b/README.md
@@ -84,21 +84,29 @@
         # Copy the .app file
         cp -R dist/RstEyeApp.app distroot/Applications/
 
-        # Create the postinstall script inside mac_os_files
-        cat <<EOF > mac_os_files/postinstall
-        #!/bin/bash
-        cp /Library/LaunchDaemons/com.rsteye.rsteye.plist
-        launchctl load /Library/LaunchDaemons/com.rsteye.rsteye.plist
-        EOF
+        # create scripts files  
+        Create postinstall, preinstall and user_input.applescript files 
 
-        # Make the postinstall script executable
-        chmod +x mac_os_files/postinstall
+        # Make the script files executable
+        chmod +x mac_os_files/scripts/* 
 
         # Ensure the plist file is ready and accessible in mac_os_files
         # Example: cp ./com.rsteye.rsteye.plist mac_os_files/
 
         # Build the installer package
-        pkgbuild --root distroot --scripts mac_os_files --identifier com.rsteye.rsteye --version 1.0 RstEyeApp.pkg
+        `pkgbuild --root dist/RstEyeApp.app \
+         --scripts mac_os_files/scripts \
+         --identifier com.rsteye.rsteye \
+         --version 1.0 \
+         --install-location /Applications/RstEyeApp \
+         mac_os_files/RstEyeApp.pkg`
+
+        # Final installer 
+        `productbuild --distribution mac_os_files/distribution.xml \
+             --resources mac_os_files/resources \
+             --package-path mac_os_files \
+             --version 1.0 \
+             RstEyeAppInstaller.pkg`
 
     - DEBUG 
       - Check system logs:
@@ -123,17 +131,4 @@
 
     - Install Inno setup(https://jrsoftware.org/isdl.php#stable) for windows and run below command to generate an installer 
       - "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" setup.iss
- 
 
-
-# TODO
-
- - [X] create deb packge for debian  
- - [X] create zip for mac 
- - [X] Create installer for Windows 
-
-  Significant Enhancements:
-
- - [X] Convert binary into a daemon binary, and create a service file for systemd.
- - [ ] Implement logging functionality and enable users to close the window. If the user closes it for over 3 hours, display a message emphasizing its  importance.
- - [ ] Consider rewriting the entire application in C++ for improved performance, especially since we'll utilize multithreading for logging and dealing with daemon binaries.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@
         # Build the installer package
         pkgbuild --root distroot --scripts mac_os_files --identifier com.rsteye.rsteye --version 1.0 RstEyeApp.pkg
 
+    - DEBUG 
+      - Check system logs:
+        - sudo launchctl list | grep com.rsteye.rsteye
+      - Check system logs:
+        - log show --predicate 'process =="RstEyeApp"' --info --last 1h
+
+
 
 
   - Windows

--- a/mac_os_files/com.rsteye.rsteye.plist
+++ b/mac_os_files/com.rsteye.rsteye.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rsteye.rsteye</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/RstEyeApp.app/Contents/MacOS/RstEyeApp</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>

--- a/mac_os_files/distribution.xml
+++ b/mac_os_files/distribution.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <title>RstEyeApp Installer</title>
+    <welcome>
+        <file>Welcome.rtf</file>
+    </welcome>
+    <license>
+        <file>License.rtf</file>
+    </license>
+    <pkg-ref id="com.rsteye.rsteye"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.rsteye.rsteye"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.rsteye.rsteye" visible="false">
+        <pkg-ref id="com.rsteye.rsteye"/>
+    </choice>
+    <pkg-ref id="com.rsteye.rsteye" version="1.0" auth="Root">file:./RstEyeApp.pkg</pkg-ref>
+</installer-gui-script>

--- a/mac_os_files/postinstall
+++ b/mac_os_files/postinstall
@@ -1,0 +1,3 @@
+#!/bin/bash
+cp com.rsteye.rsteye.plist /Library/LaunchDaemons/
+launchctl load /Library/LaunchDaemons/com.rsteye.rsteye.plist

--- a/mac_os_files/postinstall
+++ b/mac_os_files/postinstall
@@ -1,3 +1,3 @@
 #!/bin/bash
-cp com.rsteye.rsteye.plist /Library/LaunchDaemons/
+cp mac_os_files/com.rsteye.rsteye.plist /Library/LaunchDaemons/
 launchctl load /Library/LaunchDaemons/com.rsteye.rsteye.plist

--- a/mac_os_files/resources/License.rtf
+++ b/mac_os_files/resources/License.rtf
@@ -1,0 +1,26 @@
+{\rtf1\ansi\deff0
+{\fonttbl
+{\f0\fnil\fcharset0 Arial;}
+}
+{\colortbl;\red0\green0\blue0;\red255\green255\blue255;}
+\paperw12240\paperh15840\margl1440\margr1440\margb1440\margt1440
+\pard\ql\qnatural\pardirnatural\partightenfactor0
+
+\f0\fs32 \cf0 RstEyeApp License Agreement\
+\
+Please read the following terms and conditions carefully before using this software.\
+\
+1. License Grant:\
+RstEye grants you a non-exclusive, non-transferable, limited license to use the RstEyeApp software.\
+\
+2. Restrictions:\
+You may not modify, reverse engineer, decompile, or disassemble the software.\
+\
+3. Termination:\
+This license will terminate automatically if you fail to comply with the terms and conditions of this agreement.\
+\
+4. Disclaimer of Warranty:\
+This software is provided "as-is" without warranty of any kind.\
+\
+By clicking "Agree" or installing the software, you acknowledge that you have read and understand this agreement, and agree to be bound by its terms.\
+}

--- a/mac_os_files/resources/Welcome.rtf
+++ b/mac_os_files/resources/Welcome.rtf
@@ -1,0 +1,16 @@
+{\rtf1\ansi\deff0
+{\fonttbl
+{\f0\fnil\fcharset0 Arial;}
+}
+{\colortbl;\red0\green0\blue0;\red255\green255\blue255;}
+\paperw12240\paperh15840\margl1440\margr1440\margb1440\margt1440
+\pard\ql\qnatural\pardirnatural\partightenfactor0
+
+\f0\fs32 \cf0 Welcome to the RstEyeApp Installer\
+\
+This installer will guide you through the steps necessary to install the RstEyeApp on your system.\
+\
+Please follow the instructions on each screen to complete the installation process.\
+\
+Click "Continue" to begin.\
+}

--- a/mac_os_files/scripts/postinstall
+++ b/mac_os_files/scripts/postinstall
@@ -1,3 +1,7 @@
 #!/bin/bash
+
+# Copy and load the main plist file
 cp mac_os_files/com.rsteye.rsteye.plist /Library/LaunchDaemons/
 launchctl load /Library/LaunchDaemons/com.rsteye.rsteye.plist
+
+exit 0

--- a/mac_os_files/scripts/preinstall
+++ b/mac_os_files/scripts/preinstall
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Run the AppleScript to get user input
+osascript user_input.applescript
+
+# Read the input values
+POPUP_INTERVAL=$(cat /tmp/POPUP_INTERVAL)
+POPUP_DURATION=$(cat /tmp/POPUP_DURATION)
+
+# Export the variables so they are available to the installer
+export POPUP_INTERVAL
+export POPUP_DURATION
+
+# Persist the variables using launchctl
+launchctl setenv POPUP_INTERVAL "$POPUP_INTERVAL"
+launchctl setenv POPUP_DURATION "$POPUP_DURATION"
+
+# Create a plist file to persist the environment variables
+cat <<EOF >/Library/LaunchDaemons/com.rsteye.env.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rsteye.env</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/launchctl</string>
+        <string>setenv</string>
+        <string>POPUP_INTERVAL</string>
+        <string>$POPUP_INTERVAL</string>
+        <string>/bin/launchctl</string>
+        <string>setenv</string>
+        <string>POPUP_DURATION</string>
+        <string>$POPUP_DURATION</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+# Load the plist to set the environment variables
+launchctl load /Library/LaunchDaemons/com.rsteye.env.plist
+
+exit 0

--- a/mac_os_files/scripts/user_input.applescript
+++ b/mac_os_files/scripts/user_input.applescript
@@ -1,0 +1,5 @@
+set POPUP_INTERVAL to text returned of (display dialog "Enter POPUP_INTERVAL (in seconds):" default answer "60")
+set POPUP_DURATION to text returned of (display dialog "Enter POPUP_DURATION (in seconds):" default answer "10")
+
+do shell script "echo " & POPUP_INTERVAL & " > /tmp/POPUP_INTERVAL"
+do shell script "echo " & POPUP_DURATION & " > /tmp/POPUP_DURATION"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configuration file for the `com.rsteye.rsteye` service on macOS.
  - Introduced a post-installation script for macOS to manage service setup.

- **Documentation**
  - Updated README with new packaging and deployment commands for macOS, Windows, and Linux.
  - Added instructions for creating installer packages and debugging on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->